### PR TITLE
Fix: Improve error handling in profiles API functions

### DIFF
--- a/src/lib/api/profiles.ts
+++ b/src/lib/api/profiles.ts
@@ -8,41 +8,41 @@ export type ProfileUpdate = Database['public']['Tables']['profiles']['Update'];
 
 // Get the current user's profile
 export async function getCurrentProfile(): Promise<ApiResponse<Profile>> {
-  const { data: { user } } = await supabase.auth.getUser();
-  
-  if (!user) throw new Error('No authenticated user');
-  
-  return handleApiError(
-    supabase
+  return handleApiError(async () => {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    
+    if (authError) throw authError;
+    if (!user) throw new Error('No authenticated user');
+    
+    const { data, error } = await supabase
       .from('profiles')
       .select('*')
       .eq('id', user.id)
-      .single()
-      .then(({ data, error }) => {
-        if (error) throw error;
-        return data as Profile;
-      })
-  );
+      .single();
+      
+    if (error) throw error;
+    return data as Profile;
+  });
 }
 
 // Update the current user's profile
 export async function updateProfile(updates: ProfileUpdate): Promise<ApiResponse<Profile>> {
-  const { data: { user } } = await supabase.auth.getUser();
-  
-  if (!user) throw new Error('No authenticated user');
-  
-  return handleApiError(
-    supabase
+  return handleApiError(async () => {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    
+    if (authError) throw authError;
+    if (!user) throw new Error('No authenticated user');
+    
+    const { data, error } = await supabase
       .from('profiles')
       .update(updates)
       .eq('id', user.id)
       .select()
-      .single()
-      .then(({ data, error }) => {
-        if (error) throw error;
-        return data as Profile;
-      })
-  );
+      .single();
+      
+    if (error) throw error;
+    return data as Profile;
+  });
 }
 
 // Create a profile for a new user (called after signup)


### PR DESCRIPTION
This PR improves error handling in the profiles API functions by properly wrapping supabase.auth.getUser() calls in the handleApiError utility function or try/catch blocks.